### PR TITLE
fix: set the cpu frequency scaling drivers to y

### DIFF
--- a/debian/patches/linux/0002-feat-Radxa-custom-kernel-config.patch
+++ b/debian/patches/linux/0002-feat-Radxa-custom-kernel-config.patch
@@ -5,8 +5,8 @@ Subject: [PATCH] feat: Radxa custom kernel config
 
 Signed-off-by: ZHANG Yuntian <yt@radxa.com>
 ---
- src/arch/arm64/configs/radxa_custom.config | 10 ++++++++++
- 1 file changed, 10 insertions(+)
+ src/arch/arm64/configs/radxa_custom.config | 14 ++++++++++
+ 1 file changed, 14 insertions(+)
  create mode 100644 src/arch/arm64/configs/radxa_custom.config
 
 diff --git a/src/arch/arm64/configs/radxa_custom.config b/src/arch/arm64/configs/radxa_custom.config
@@ -14,12 +14,16 @@ new file mode 100644
 index 000000000000..d9550fafb022
 --- /dev/null
 +++ b/src/arch/arm64/configs/radxa_custom.config
-@@ -0,0 +1,10 @@
+@@ -0,0 +1,14 @@
 +# RK3399's midgard driver is not updated yet
 +CONFIG_MALI_MIDGARD=n
 +
 +# cpufreq_interactive uses unexported functions
 +CONFIG_CPU_FREQ_GOV_INTERACTIVE=y
++
++# Enable the CPU frequency scaling drivers and set them to y
++CONFIG_CPUFREQ_DT=y
++CONFIG_ARM_ROCKCHIP_CPUFREQ=y
 +
 +# Fix build error: 'dw8250_do_set_termios' exported twice
 +CONFIG_SERIAL_8250=y


### PR DESCRIPTION
When `CONFIG_CPUFREQ_DT` is set as a module `m`, the driver may be loaded multiple times, causing conflicts that lead to illegal memory access and a kernel crash.